### PR TITLE
Improved remote controller interception

### DIFF
--- a/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCL/Clusters/General/Source/LevelControlCommandHandler.c
+++ b/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCL/Clusters/General/Source/LevelControlCommandHandler.c
@@ -294,6 +294,15 @@ PRIVATE  teZCL_Status eCLD_LevelControlHandleMoveToLevelCommand(
         DBG_vPrintf(TRACE_LEVEL_CONTROL, " Err:%d", eStatus);
         return eStatus;
     }
+
+    /* Message data for callback */
+    psCommon->sCallBackMessage.uMessage.psMoveToLevelCommandPayload = &sPayload;
+
+    /* call callback */
+    psEndPointDefinition->pCallBackFunctions(&psCommon->sCustomCallBackEvent);
+
+    return E_ZCL_SUCCESS;
+
 
     /* 3.10.2.2  Generic usage notes
      * If a move to level, move, step or stop command is received while the
@@ -436,6 +445,14 @@ PRIVATE  teZCL_Status eCLD_LevelControlHandleMoveCommand(
         DBG_vPrintf(TRACE_LEVEL_CONTROL, " Err:%d", eStatus);
         return eStatus;
     }
+
+    /* Message data for callback */
+    psCommon->sCallBackMessage.uMessage.psMoveCommandPayload = &sPayload;
+
+    /* call callback */
+    psEndPointDefinition->pCallBackFunctions(&psCommon->sCustomCallBackEvent);
+
+    return E_ZCL_SUCCESS;
 
     /* 3.10.2.2  Generic usage notes
      * If a move to level, move, step or stop command is received while the
@@ -578,6 +595,14 @@ PRIVATE  teZCL_Status eCLD_LevelControlHandleStepCommand(
         return eStatus;
     }
 
+    /* Message data for callback */
+    psCommon->sCallBackMessage.uMessage.psStepCommandPayload = &sPayload;
+
+    /* call callback */
+    psEndPointDefinition->pCallBackFunctions(&psCommon->sCustomCallBackEvent);
+
+    return E_ZCL_SUCCESS;
+
     /* 3.10.2.2  Generic usage notes
      * If a move to level, move, step or stop command is received while the
      * device is in its off state, i.e. the OnOff attribute of the on/off
@@ -724,6 +749,15 @@ PRIVATE  teZCL_Status eCLD_LevelControlHandleStopCommand(
         DBG_vPrintf(TRACE_LEVEL_CONTROL, " Err:%d", eStatus);
         return eStatus;
     }
+
+    /* Message data for callback */
+    psCommon->sCallBackMessage.uMessage.psStopCommandPayload = &sPayload;
+    
+    /* call callback */
+    psEndPointDefinition->pCallBackFunctions(&psCommon->sCustomCallBackEvent);
+
+    return E_ZCL_SUCCESS;
+
 
 #if ((defined CLD_ONOFF) && (defined ONOFF_SERVER))
     if(u8CommandIdentifier == E_CLD_LEVELCONTROL_CMD_STOP)

--- a/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCL/Clusters/General/Source/OnOffCommandHandler.c
+++ b/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCL/Clusters/General/Source/OnOffCommandHandler.c
@@ -73,6 +73,7 @@
 
 #include "zcl_options.h"
 
+
 #include "dbg.h"
 #ifdef DEBUG_CLD_ONOFF
 #define TRACE_ONOFF TRUE
@@ -178,7 +179,6 @@ PUBLIC  teZCL_Status eCLD_OnOffCommandHandler(
 
 	tsZCL_HeaderParams sZCL_HeaderParams;
     DBG_vPrintf(TRACE_ONOFF, "\nONOFF: ");
-
 
     // further error checking can only be done once we have interrogated the ZCL payload
     u16ZCL_ReadCommandHeader(pZPSevent->uEvent.sApsDataIndEvent.hAPduInst,
@@ -486,7 +486,9 @@ PRIVATE  teZCL_Status eCLD_OnOffHandleToggleCommand(
         DBG_vPrintf(TRACE_ONOFF, "Error: %d", eStatus);
         return(E_ZCL_FAIL);
     }
-
+  
+    return eStatus;
+
 
     /*
      * 6.6.1.4.3 Toggle command extensions


### PR DESCRIPTION
This will broke default function of ZiGate's OnOff and LevelControl command handling, but I don't think that does matter since ZiGate is not supposed to control any light hardware. With these modifications ZiGate will report incoming commands but won't execute functions which would change ZiGate's OnOff state and Level state. When OnOff state doesn't matter ZiGate is able to report LevelControl commands every time. Improving #64