### PR TITLE
Added PDM migration for version changing

### DIFF
--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/PDM_IDs.h
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/PDM_IDs.h
@@ -67,6 +67,21 @@ extern "C" {
 #define PDM_ID_APP_END_P_TABLE      0x2
 #define PDM_ID_APP_GROUP_TABLE      0x3
 
+#define PDM_ID_APP_VERSION                  0x10
+
+#define PDM_ID_INTERNAL_AIB                 0xf000
+#define PDM_ID_INTERNAL_BINDS               0xf001
+#define PDM_ID_INTERNAL_GROUPS              0xf002
+#define PDM_ID_INTERNAL_APS_KEYS            0xf003
+#define PDM_ID_INTERNAL_TC_TABLE            0xf004
+#define PDM_ID_INTERNAL_TC_LOCATIONS        0xf005
+#define PDM_ID_INTERNAL_NIB_PERSIST         0xf100
+#define PDM_ID_INTERNAL_CHILD_TABLE         0xf101
+#define PDM_ID_INTERNAL_SHORT_ADDRESS_MAP   0xf102
+#define PDM_ID_INTERNAL_NWK_ADDRESS_MAP     0xf103
+#define PDM_ID_INTERNAL_ADDRESS_MAP_TABLE   0xf104
+#define PDM_ID_INTERNAL_SEC_MATERIAL_KEY    0xf105
+
 #ifdef  CLD_GREENPOWER
 #define PDM_ID_APP_CLD_GP_TRANS_TABLE       (0xA103)
 #define PDM_ID_APP_CLD_GP_SINK_PROXY_TABLE  (0xA104)

--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/SerialLink.h
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/SerialLink.h
@@ -141,6 +141,10 @@ typedef enum
     E_SL_MSG_UNBIND_GROUP                                      =   0x0033,
     E_SL_MSG_UNBIND_GROUP_RESPONSE                             =   0x8033,
 
+#ifdef PDM_DEBUG
+    E_SL_MSG_DEBUG_PDM                                         =   0x0034,
+#endif
+
     E_SL_MSG_MANY_TO_ONE_ROUTE_REQUEST                         =   0x004F,
     E_SL_MSG_COMPLEX_DESCRIPTOR_REQUEST                        =   0x0531,
     E_SL_MSG_COMPLEX_DESCRIPTOR_RESPONSE                       =   0x8531,

--- a/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZigbeeCommon/Include/appZpsExtendedDebug.h
+++ b/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZigbeeCommon/Include/appZpsExtendedDebug.h
@@ -1,0 +1,72 @@
+/*****************************************************************************
+ *
+ * MODULE:      Utils
+ *
+ * COMPONENT:   appZdpExtendedDebug.h
+ *
+ * AUTHOR:      nxp29741
+ *
+ * DESCRIPTION:
+ *
+ * $HeadURL:  $
+ *
+ * $Revision:  $
+ *
+ * $LastChangedBy: nxp29741 $
+ *
+ * $LastChangedDate: $
+ *
+ * $Id:  $
+ *
+ *****************************************************************************
+ *
+ * This software is owned by NXP B.V. and/or its supplier and is protected
+ * under applicable copyright laws. All rights are reserved. We grant You,
+ * and any third parties, a license to use this software solely and
+ * exclusively on NXP products [NXP Microcontrollers such as JN5168, JN5179].
+ * You, and any third parties must reproduce the copyright and warranty notice
+ * and any other legend of ownership on each copy or partial copy of the
+ * software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Copyright NXP B.V. 2016. All rights reserved
+ *
+ ****************************************************************************/
+
+#ifndef APPZDPEXTENDEDDEBUG_H_
+#define APPZDPEXTENDEDDEBUG_H_
+
+#include <jendefs.h>
+#include <string.h>
+#include "zps_apl_af.h"
+#include "zps_apl_aib.h"
+#include "zps_nwk_sap.h"
+#include "zps_nwk_nib.h"
+#include "zps_nwk_pub.h"
+#include "dbg.h"
+
+
+PUBLIC void vDisplayTableSizes(void);
+PUBLIC void vDisplayAddressMapTable(void);
+PUBLIC void vDisplayNT(void);
+PUBLIC void vDisplayAPSTable(void);
+PUBLIC void vDisplayDiscNT(void);
+PUBLIC void vDisplayRoutingTable(void);
+PUBLIC void vDisplayRouteRecordTable(void);
+PUBLIC void vDisplayNWKKey(void);
+PUBLIC void vDisplayNWKTransmitTable(void);
+PUBLIC void vDisplayBindingTable(void);
+
+
+#endif

--- a/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZigbeeCommon/Source/appZpsExtendedDebug.c
+++ b/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZigbeeCommon/Source/appZpsExtendedDebug.c
@@ -174,7 +174,7 @@ PUBLIC void vDisplayAddressMapTable(void)
 
     for( i=0;i<thisNib->sTblSize.u16AddrMap;i++)
     {
-        DBG_vPrintf(TRACE_ZBP_UTILS,"\nShort Addr: %04x, Ext Addr: %016llx,", thisNib->sTbl.pu16AddrMapNwk[i], ZPS_u64NwkNibGetMappedIeeeAddr(ZPS_pvAplZdoGetNwkHandle(),thisNib->sTbl.pu16AddrLookup[i]));
+        DBG_vPrintf(TRACE_ZBP_UTILS,"\nShort Addr: %04x, Ext Addr: %016llx,", thisNib->sTbl.pu16AddrMapNwk[i], ZPS_u64NwkNibGetMappedIeeeAddr(ZPS_pvAplZdoGetNwkHandle(),thisNib->sTbl.psNtActv[i].u16Lookup));
     }
 }
 
@@ -201,8 +201,9 @@ PUBLIC void vDisplayNT( void )
 
     for( i = 0 ; i < thisNib->sTblSize.u16NtActv ; i++ )
     {
-        DBG_vPrintf(TRACE_ZBP_UTILS, "SAddr: 0x%04x - ExtAddr: 0x%016llx - LQI: %i - Failed TX's: %i - Auth: %i - %i %i %i %i %i %i - Active: %i - %i %i %i\n",
+        DBG_vPrintf(TRACE_ZBP_UTILS, "SAddr: 0x%04x - 0x%04x ExtAddr: 0x%016llx - LQI: %i - Failed TX's: %i - Auth: %i - %i %i %i %i %i %i - Active: %i - %i %i %i\n",
                     thisNib->sTbl.psNtActv[i].u16NwkAddr,
+                    thisNib->sTbl.psNtActv[i].u16Lookup,
                     ZPS_u64NwkNibGetMappedIeeeAddr(ZPS_pvAplZdoGetNwkHandle(),thisNib->sTbl.psNtActv[i].u16Lookup),
                     thisNib->sTbl.psNtActv[i].u8LinkQuality,
                     thisNib->sTbl.psNtActv[i].u8TxFailed,
@@ -567,8 +568,10 @@ void vDisplayNWKKey(void)
         DBG_vPrintf(TRACE_ZBP_UTILS, "APP: Key");
         for(i = 0;i<16;i++)
         {
-             DBG_vPrintf(TRACE_ZBP_UTILS, "%x", thisNib->sTbl.psSecMatSet[j].au8Key[i]);
+             DBG_vPrintf(TRACE_ZBP_UTILS, "%x ", thisNib->sTbl.psSecMatSet[j].au8Key[i]);
         } 
+        DBG_vPrintf(TRACE_ZBP_UTILS, " | %x ", thisNib->sTbl.psSecMatSet[j].u8KeySeqNum);
+        DBG_vPrintf(TRACE_ZBP_UTILS, " | %x ", thisNib->sTbl.psSecMatSet[j].u8KeyType);
 
          DBG_vPrintf(TRACE_ZBP_UTILS, "\r\n");
      }


### PR DESCRIPTION
Added functionality for migration between versions while keeping paired devices. Support starts from version 3.0e. 

ZiGate will check current firmware version from PDM after PDM initialization. If version has changed then PDM structures will be resized to correct sizes. If no PDM structures are found then only version information will be added to PDM. It's important to make sure that new structure sizes are added before releasing new version. 

I have tested this with Ikea bulb, xiaomi leak and motion sensors and with 3.0e and 3.0f firmwares.