### PR TITLE
Fixes #101 #161 #47

### DIFF
--- a/Module Radio/Firmware/src/ZiGate/Source/Common/app_common.h
+++ b/Module Radio/Firmware/src/ZiGate/Source/Common/app_common.h
@@ -139,10 +139,10 @@ extern uint8 u8GPZCLTimerEvent;
 typedef enum
 {
     E_STARTUP,
+    E_RUNNING,
 #ifdef FULL_FUNC_DEVICE
     E_NFN_START,
 #endif
-    E_RUNNING,
 } teNODE_STATES;
 
 typedef struct {

--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_general_events_handler.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_general_events_handler.c
@@ -847,24 +847,33 @@ PUBLIC void APP_vHandleStackEvents ( ZPS_tsAfEvent*    psStackEvent )
                     }
                     break;
 
+                    case ZPS_ZDP_BIND_RSP_CLUSTER_ID:
+                        ZNC_BUF_U8_UPD   ( &au8LinkTxBuffer [u16Length], sApsZdpEvent.uZdpData.sUnbindRsp.u8Status,    u16Length );
+                        ZNC_BUF_U8_UPD   ( &au8LinkTxBuffer [u16Length], psStackEvent->uEvent.sApsDataIndEvent.u8SrcEndpoint, u16Length );
+                        ZNC_BUF_U8_UPD   ( &au8LinkTxBuffer [u16Length], psStackEvent->uEvent.sApsDataIndEvent.u8SrcAddrMode, u16Length );
+                        ZNC_BUF_U16_UPD  ( &au8LinkTxBuffer [u16Length],  psStackEvent->uEvent.sApsDataIndEvent.uSrcAddress.u16Addr,    u16Length );
+                        vSL_WriteMessage ( E_SL_MSG_BIND_RESPONSE,
+                                            u16Length,
+                                            au8LinkTxBuffer,
+                                            u8LinkQuality );
+                    break;
+
+                    case ZPS_ZDP_UNBIND_RSP_CLUSTER_ID:
+                        ZNC_BUF_U8_UPD   ( &au8LinkTxBuffer [u16Length], sApsZdpEvent.uZdpData.sUnbindRsp.u8Status,    u16Length );
+                        ZNC_BUF_U8_UPD   ( &au8LinkTxBuffer [u16Length], psStackEvent->uEvent.sApsDataIndEvent.u8SrcEndpoint, u16Length );
+                        ZNC_BUF_U8_UPD   ( &au8LinkTxBuffer [u16Length], psStackEvent->uEvent.sApsDataIndEvent.u8SrcAddrMode, u16Length );
+                        ZNC_BUF_U16_UPD  ( &au8LinkTxBuffer [u16Length],  psStackEvent->uEvent.sApsDataIndEvent.uSrcAddress.u16Addr,    u16Length );
+                        vSL_WriteMessage ( E_SL_MSG_UNBIND_RESPONSE,
+                                           u16Length,
+                                           au8LinkTxBuffer,
+                                           u8LinkQuality );
+                    break;
+
                     default:
                     {
-                        ZNC_BUF_U8_UPD   ( &au8LinkTxBuffer [u16Length] , sApsZdpEvent.uZdpData.sUnbindRsp.u8Status,    u16Length );
+                        ZNC_BUF_U8_UPD ( &au8LinkTxBuffer [u16Length], sApsZdpEvent.uZdpData.sUnbindRsp.u8Status,    u16Length );
                         switch ( sApsZdpEvent.u16ClusterId )
                         {
-                             case ZPS_ZDP_BIND_RSP_CLUSTER_ID:
-                                 vSL_WriteMessage ( E_SL_MSG_BIND_RESPONSE,
-                                                    u16Length,
-                                                    au8LinkTxBuffer,
-                                                    u8LinkQuality );
-                             break;
-
-                             case ZPS_ZDP_UNBIND_RSP_CLUSTER_ID:
-                                 vSL_WriteMessage ( E_SL_MSG_UNBIND_RESPONSE,
-                                                    u16Length,
-                                                    au8LinkTxBuffer,
-                                                    u8LinkQuality );
-                             break;
                              case ZPS_ZDP_MGMT_LEAVE_RSP_CLUSTER_ID:
                                  vSL_WriteMessage ( E_SL_MSG_MANAGEMENT_LEAVE_RESPONSE,
                                                     u16Length,

--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_general_events_handler.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_general_events_handler.c
@@ -869,29 +869,16 @@ PUBLIC void APP_vHandleStackEvents ( ZPS_tsAfEvent*    psStackEvent )
                                            u8LinkQuality );
                     break;
 
-                    default:
-                    {
-                        ZNC_BUF_U8_UPD ( &au8LinkTxBuffer [u16Length], sApsZdpEvent.uZdpData.sUnbindRsp.u8Status,    u16Length );
-                        switch ( sApsZdpEvent.u16ClusterId )
-                        {
-                             case ZPS_ZDP_MGMT_LEAVE_RSP_CLUSTER_ID:
-                                 vSL_WriteMessage ( E_SL_MSG_MANAGEMENT_LEAVE_RESPONSE,
-                                                    u16Length,
-                                                    au8LinkTxBuffer,
-                                                    u8LinkQuality );
-                             break;
+                    case ZPS_ZDP_MGMT_PERMIT_JOINING_RSP_CLUSTER_ID:
+                        ZNC_BUF_U8_UPD ( &au8LinkTxBuffer [u16Length], sApsZdpEvent.uZdpData.sPermitJoiningRsp.u8Status,    u16Length );
+                        vSL_WriteMessage ( E_SL_MSG_PERMIT_JOINING_RESPONSE,
+                                           u16Length,
+                                           au8LinkTxBuffer,
+                                           u8LinkQuality );
+                     break;
 
-                             case ZPS_ZDP_MGMT_PERMIT_JOINING_RSP_CLUSTER_ID:
-                                 vSL_WriteMessage ( E_SL_MSG_PERMIT_JOINING_RESPONSE,
-                                                    u16Length,
-                                                    au8LinkTxBuffer,
-                                                    u8LinkQuality );
-                             break;
-                             default:
-                             break;
-                        }
-                    }
-                        break;
+                    default:
+                    break;
                     }
                 }
             }

--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
@@ -260,7 +260,13 @@ void APP_vHandleZclEvents ( ZPS_tsAfEvent*    psStackEvent )
                 ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [u16Length], psStackEvent->uEvent.sApsDataConfirmEvent.u8SrcEndpoint,       u16Length );
                 ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [u16Length], psStackEvent->uEvent.sApsDataConfirmEvent.u8DstEndpoint,       u16Length );
                 ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [u16Length], psStackEvent->uEvent.sApsDataConfirmEvent.u8DstAddrMode,       u16Length );
-                ZNC_BUF_U64_UPD ( &au8LinkTxBuffer [u16Length], psStackEvent->uEvent.sApsDataConfirmEvent.uDstAddr.u64Addr,    u16Length );
+                if (psStackEvent->uEvent.sApsDataConfirmEvent.u8DstAddrMode == 0x03)
+                {
+                    ZNC_BUF_U64_UPD ( &au8LinkTxBuffer [u16Length], psStackEvent->uEvent.sApsDataConfirmEvent.uDstAddr.u64Addr, u16Length );
+                }else
+                {
+                    ZNC_BUF_U16_UPD ( &au8LinkTxBuffer [u16Length], psStackEvent->uEvent.sApsDataConfirmEvent.uDstAddr.u16Addr, u16Length );
+                }
                 ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [u16Length], psStackEvent->uEvent.sApsDataConfirmEvent.u8SequenceNum,       u16Length );
                 vSL_WriteMessage ( E_SL_MSG_APS_DATA_CONFIRM_FAILED,
                                    u16Length,


### PR DESCRIPTION
Rearranged teNODE_STATES to logical in all cases #101 

Changed 8702 to respect address mode. #161 #47
Previously destination address parameter was always formated to uint64 even if it was short address or group. Now it respects address mode same way as other event responses.

Added fields for 0x8030, 0x8031
Both responses now include source endpoint, addressmode and short
address. #122

Removed double case and tidying code
ZPS_ZDP_MGMT_LEAVE_RSP_CLUSTER_ID was checked twice.