### PR TITLE
Added cmd 0807 Get Tx Power

### DIFF
--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/SerialLink.h
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/SerialLink.h
@@ -334,6 +334,8 @@ typedef enum
     E_SL_MSG_AHI_DIO_READ_INPUT                                 =  0x0803,
     E_SL_MSG_AHI_DIO_READ_INPUT_RSP                             =  0x8803,
     E_SL_MSG_AHI_SET_TX_POWER                                   =  0x0806,
+    E_SL_MSG_AHI_GET_TX_POWER                                   =  0x0807,
+    E_SL_MSG_AHI_GET_TX_POWER_RSP                               =  0x8807,
 } teSL_MsgType;
 typedef enum
 {

--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/SerialLink.h
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/SerialLink.h
@@ -334,6 +334,7 @@ typedef enum
     E_SL_MSG_AHI_DIO_READ_INPUT                                 =  0x0803,
     E_SL_MSG_AHI_DIO_READ_INPUT_RSP                             =  0x8803,
     E_SL_MSG_AHI_SET_TX_POWER                                   =  0x0806,
+    E_SL_MSG_AHI_SET_TX_POWER_RSP                               =  0x8806,
     E_SL_MSG_AHI_GET_TX_POWER                                   =  0x0807,
     E_SL_MSG_AHI_GET_TX_POWER_RSP                               =  0x8807,
 } teSL_MsgType;

--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_Znc_cmds.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_Znc_cmds.c
@@ -598,7 +598,7 @@ PUBLIC void APP_vProcessIncomingSerialCommands ( uint8    u8RxByte )
             case (E_SL_MSG_RESET):
             {
                 bResetIssued    =  TRUE;
-                ZTIMER_eStart( u8IdTimer, ZTIMER_TIME_MSEC ( 1 ) );
+                ZTIMER_eStart( u8IdTimer, ZTIMER_TIME_MSEC ( 20 ) );
 
             }
             break;

--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_Znc_cmds.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_Znc_cmds.c
@@ -354,6 +354,7 @@ PUBLIC void APP_vProcessIncomingSerialCommands ( uint8    u8RxByte )
                                       au8values,
                                       0);
                 }
+                return;
             }
             #endif
     	}

--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_ahi_commands.h
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_ahi_commands.h
@@ -54,10 +54,10 @@ typedef enum
 /****************************************************************************/
 /***        Exported Functions                                            ***/
 /****************************************************************************/
-PUBLIC void APP_vCMDHandleAHICommand(uint16 u16PacketType,
-                                     uint16 u16PacketLength,
-                                     uint8 *pu8LinkRxBuffer,
-                                     uint8 *pu8Status);
+PUBLIC uint32 APP_vCMDHandleAHICommand(uint16 u16PacketType,
+                                       uint16 u16PacketLength,
+                                       uint8 *pu8LinkRxBuffer,
+                                       uint8 *pu8Status);
 PUBLIC void vAPP_IpnStatsOutput(void);
 PUBLIC void vAPP_IpnStatsReset(void);
 


### PR DESCRIPTION
Command 0x0807 Get Tx Power doesn't need any parameters. If command is handled successfully response will be first status(0x8000) with success status and after that Get Tx Power Response(0x8807). 0x8807 has only single parameter which is uint8 power. If 0x0807 fails then response is going to be only status(0x8000) with status 1.

Standard power modules of JN516X(Except JN5169) modules have only 4 possible power levels (Table 5 JN-UG-3024 v2.6). These levels are based on some kind of hardware registry so there is no way to change them in firmware. In ZiGate's case this means:

Set/get tx value | Mapped value (dBM)
----------------|----------------------
0 to 31 | 0
32 to 39 | -32
40 to 51 | -20
52 to 63 | -9

JN5169 has 26 levels more information mapping of those can be found from https://community.nxp.com/thread/494272

#145 