### PR TITLE
Added IAS WD Squawk command 0x0112

### DIFF
--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/SerialLink.h
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/SerialLink.h
@@ -284,6 +284,7 @@ typedef enum
     E_SL_MSG_WRITE_ATTRIBUTE_REQUEST                            =  0x0110,
     E_SL_MSG_WRITE_ATTRIBUTE_RESPONSE                           =  0x8110,
     E_SL_MSG_WRITE_ATTRIBUTE_REQUEST_IAS_WD                     =  0x0111,
+    E_SL_MSG_WRITE_ATTRIBUTE_REQUEST_IAS_WD_SQUAWK              =  0x0112,
     E_SL_MSG_CONFIG_REPORTING_REQUEST                           =  0x0120,
     E_SL_MSG_CONFIG_REPORTING_RESPONSE                          =  0x8120,
     E_SL_MSG_REPORT_ATTRIBUTES                                  =  0x8121,

--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_Znc_cmds.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_Znc_cmds.c
@@ -1948,6 +1948,27 @@ PUBLIC void APP_vProcessIncomingSerialCommands ( uint8    u8RxByte )
 			}
 			break;
 
+            case (E_SL_MSG_WRITE_ATTRIBUTE_REQUEST_IAS_WD_SQUAWK):
+            {
+
+                tsZCL_TxPayloadItem asPayloadDefinition[] = {
+                        {1, E_ZCL_ENUM8,  (void *)&au8LinkRxBuffer [ 9] },
+                };
+
+                u8Status =  eZCL_CustomCommandSend(au8LinkRxBuffer [ 3 ],
+                                                  au8LinkRxBuffer [ 4 ],
+                                                  &sAddress,
+                                                  SECURITY_AND_SAFETY_CLUSTER_ID_IASWD,
+                                                  FALSE,
+                                                  E_CLD_IASWD_CMD_SQUAWK,
+                                                  &u8SeqNum,
+                                                  asPayloadDefinition,
+                                                  FALSE,
+                                                  0,
+                                                  sizeof(asPayloadDefinition) / sizeof(tsZCL_TxPayloadItem));
+            }
+            break;
+
 
             case E_SL_MSG_CONFIG_REPORTING_REQUEST:
             {


### PR DESCRIPTION
0x0112 Write Attribute request IAS_WD Squawk
```
 <address mode: uint8_t>
 <target short address: uint16_t>
 <source endpoint: uint8_t>
 <destination endpoint: uint8_t>
 <direction: uint8_t>
 <manufacturer specific: uint8_t>
 <manufacturer id: uint16_t>
 <SquawkModeStrobeAndLevel: uint8_t>
```
SquawkModeStrobeAndLevel is 8-bit bitmap

Bits | Description
----|-----------------------------------
0-3 | Squawk Mode - indicates the meaning of the required ‘squawk’:<br>0 - System is armed<br>1 - System is disarmed<br>All other values are reserved
4 | Strobe - indicates whether a visual strobe indication of the ‘squawk’ is required:<br>0 - No strobe<br>1 - Use strobe
5 | Reserved
6-7 | Squawk Level - indicates the requested level of the audible squawk sound:<br>0 - Low level<br>1 - Medium level<br>2 - High level<br>3 - Very high level

#179 