### PR TITLE
Send all not currently handled event type to raw 8002 message

### DIFF
--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/ZigbeeNodeControlBridgeCoordinator.zpscfg
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/ZigbeeNodeControlBridgeCoordinator.zpscfg
@@ -347,6 +347,16 @@
       <OutputClusters Cluster="Diagnostics" TxAPDUs="ZigbeeNodeControlBridge->apduZDP" Discoverable="true"/>
       <OutputClusters Cluster="ZLL_Commissioning" TxAPDUs="ZigbeeNodeControlBridge->apduZDP" Discoverable="true"/>
     </Endpoints>
+    <Endpoints Id="11" Enabled="true" ApplicationDeviceId="2112" ApplicationDeviceVersion="0" Profile="ZLO" Message="APP_msgZpsEvents_ZCL" Name="WISER">
+      <InputClusters Cluster="Basic" RxAPDU="ZigbeeNodeControlBridge->apduZDP" Discoverable="true"/>
+      <InputClusters Cluster="Metering" RxAPDU="ZigbeeNodeControlBridge->apduZDP" Discoverable="false"/>
+      <InputClusters Cluster="OTA" RxAPDU="ZigbeeNodeControlBridge->apduZDP" Discoverable="true"/>
+      <InputClusters Cluster="Thermostat" RxAPDU="ZigbeeNodeControlBridge->apduZDP" Discoverable="false"/>
+      <InputClusters Cluster="MEASUREMENT_AND_SENSING_CLUSTER_ID_TEMPERATURE_MEASUREMENT" RxAPDU="ZigbeeNodeControlBridge->apduZDP" Discoverable="false"/>
+      <InputClusters Cluster="Power_Configuration" RxAPDU="ZigbeeNodeControlBridge->apduZDP" Discoverable="false"/>
+      <InputClusters Cluster="Default" RxAPDU="ZigbeeNodeControlBridge->apduZDP" Discoverable="false"/>
+      <OutputClusters Cluster="Basic" TxAPDUs="ZigbeeNodeControlBridge->apduZDP" Discoverable="true"/>
+    </Endpoints>
     <Endpoints Id="10" Enabled="true" ApplicationDeviceId="2112" ApplicationDeviceVersion="0" Profile="ZLO" Message="APP_msgZpsEvents_ZCL" Name="ORVIBO">
       <InputClusters Cluster="Basic" RxAPDU="ZigbeeNodeControlBridge->apduZDP" Discoverable="true"/>
       <InputClusters Cluster="Color_Control" RxAPDU="ZigbeeNodeControlBridge->apduZDP" Discoverable="false"/>

--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
@@ -402,10 +402,17 @@ PRIVATE void APP_ZCL_cbEndpointCallback ( tsZCL_CallBackEvent*    psEvent )
     
     switch (psEvent->eEventType)
     {
+        case E_ZCL_CBET_READ_REQUEST:
+    	{
+            vLog_Printf(TRACE_ZCL, LOG_DEBUG, "EP EVT:E_ZCL_CBET_READ_REQUEST\r\n");
+            ZPS_tsAfEvent* psStackEvent = psEvent->pZPSevent;
+            Znc_vSendDataIndicationToHost(psStackEvent, au8LinkTxBuffer);
+            psEvent->eZCL_Status = E_ZCL_FAIL; // we want zcl to stop processing the request
+    	}
+        break;
         case E_ZCL_CBET_LOCK_MUTEX:
         case E_ZCL_CBET_UNLOCK_MUTEX:
         case E_ZCL_CBET_READ_ATTRIBUTES_RESPONSE:
-        case E_ZCL_CBET_READ_REQUEST:
         case E_ZCL_CBET_TIMER:
         case E_ZCL_CBET_ZIGBEE_EVENT:
             //vLog_Printf(TRACE_ZCL, "EP EVT:No action\r\n");

--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/zcl_options.h
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/zcl_options.h
@@ -66,7 +66,7 @@
 #define GROUPS_REQUIRED                                     ( 16 )
 #define CLD_GROUPS_MAX_NUMBER_OF_GROUPS                     ( 5  )
 /* Sets the number of endpoints that will be created by the ZCL library */
-#define ZCL_NUMBER_OF_ENDPOINTS                             ( 5 )
+#define ZCL_NUMBER_OF_ENDPOINTS                             ( 6 )
 #define ZCL_NUMBER_DEVICES                                  ( 1 )
 
 #define ZCL_MANUFACTURER_CODE                               ( 0x1037 )

--- a/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl.c
+++ b/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl.c
@@ -779,7 +779,7 @@ PUBLIC teZCL_Status eZCL_SearchForEPIndex(
         return E_ZCL_FAIL;
 
 
-    if ((u8endpointId==10) || (u8endpointId==0x6e) || (u8endpointId==0x15) || (u8endpointId==0x08)) {u8endpointId=1;} //FRED -- ORVIBO + TERNCY COMPATIBILITE + KONKE + LIVOLO
+    if ((u8endpointId==10) || (u8endpointId==0x6e) || (u8endpointId==0x15)  || (u8endpointId==0x0b)|| (u8endpointId==0x08)) {u8endpointId=1;} //FRED -- ORVIBO + TERNCY COMPATIBILITE + KONKE + LIVOLO + WISER
     for(i=0; i<psZCL_Common->u8NumberOfEndpoints; i++)
     {
     	//vLog_Printf(TRACE_DEBUG,LOG_DEBUG, "\n i : %d - u8EndPointNumber: %d\n",i,psZCL_Common->psZCL_EndPointRecord[i].psEndPointDefinition->u8EndPointNumber);

--- a/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl_readAttributesRequestHandle.c
+++ b/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl_readAttributesRequestHandle.c
@@ -215,13 +215,6 @@ PUBLIC   void vZCL_HandleAttributesReadRequest(
 
 
 
-
-    // call user unless null cluster instance (as no atts will be read in that case and the user may attempt to access the cluster without checking and get an exception)
-    if (psClusterInstance != NULL)
-    {
-        psZCL_EndPointDefinition->pCallBackFunctions(&sZCL_CallBackEvent);
-    }
-
     // parse the incoming message, read each attribute from the device and write into the outgoing buffer
     i = 0;
 
@@ -336,7 +329,9 @@ PUBLIC   void vZCL_HandleAttributesReadRequest(
 												 au8LinkTxBuffer,
 												 pZPSevent->uEvent.sApsDataIndEvent.u8LinkQuality);
     }
-    if (sZCL_CallBackEvent.eZCL_Status == E_ZCL_SUCCESS )
+
+    //if (sZCL_CallBackEvent.eZCL_Status == E_ZCL_SUCCESS )
+    if (u8errorCode == E_ZCL_CMDS_SUCCESS)
     {
     // build address structure
     eZCL_BuildTransmitAddressStructure(pZPSevent, &sZCL_Address);
@@ -348,6 +343,11 @@ PUBLIC   void vZCL_HandleAttributesReadRequest(
                                 pZPSevent->uEvent.sApsDataIndEvent.u16ClusterId,
                                 &sZCL_Address);
     } else {
+    	  // call user unless null cluster instance (as no atts will be read in that case and the user may attempt to access the cluster without checking and get an exception)
+   	    if (psClusterInstance != NULL)
+   	    {
+   	        psZCL_EndPointDefinition->pCallBackFunctions(&sZCL_CallBackEvent);
+   	    }
 		PDUM_eAPduFreeAPduInstance(myPDUM_thAPduInstance);
     }
 }

--- a/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl_readAttributesRequestHandle.c
+++ b/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl_readAttributesRequestHandle.c
@@ -336,7 +336,8 @@ PUBLIC   void vZCL_HandleAttributesReadRequest(
 												 au8LinkTxBuffer,
 												 pZPSevent->uEvent.sApsDataIndEvent.u8LinkQuality);
     }
-
+    if (sZCL_CallBackEvent.eZCL_Status == E_ZCL_SUCCESS )
+    {
     // build address structure
     eZCL_BuildTransmitAddressStructure(pZPSevent, &sZCL_Address);
     // transmit request
@@ -346,6 +347,9 @@ PUBLIC   void vZCL_HandleAttributesReadRequest(
                                 pZPSevent->uEvent.sApsDataIndEvent.u8SrcEndpoint,
                                 pZPSevent->uEvent.sApsDataIndEvent.u16ClusterId,
                                 &sZCL_Address);
+    } else {
+		PDUM_eAPduFreeAPduInstance(myPDUM_thAPduInstance);
+    }
 }
 
 /****************************************************************************/


### PR DESCRIPTION
Until now some events were not handled and thrown away, this patch changes the behaviour to have them sent as raw 8002 message. This will allow us to deal with read request for example from some devices