### PR TITLE
Send all not currently handled event type to raw 8002 message

### DIFF
--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
@@ -447,8 +447,7 @@ PRIVATE void APP_ZCL_cbEndpointCallback ( tsZCL_CallBackEvent*    psEvent )
         case E_ZCL_CBET_UNHANDLED_EVENT:
         {
 
-             vLog_Printf ( TRACE_ZCL, LOG_DEBUG, " (E_ZCL_CBET_UNHANDLED_EVENT)" );
-         // pour pipiche
+            vLog_Printf ( TRACE_ZCL, LOG_DEBUG, " (E_ZCL_CBET_UNHANDLED_EVENT)" );
             ZPS_tsAfEvent* psStackEvent = psEvent->pZPSevent;
             if (psStackEvent->eType == ZPS_EVENT_APS_DATA_INDICATION)
             {

--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
@@ -446,7 +446,14 @@ PRIVATE void APP_ZCL_cbEndpointCallback ( tsZCL_CallBackEvent*    psEvent )
 
         case E_ZCL_CBET_UNHANDLED_EVENT:
         {
-            vLog_Printf ( TRACE_ZCL, LOG_DEBUG, " (E_ZCL_CBET_UNHANDLED_EVENT)" );
+
+             vLog_Printf ( TRACE_ZCL, LOG_DEBUG, " (E_ZCL_CBET_UNHANDLED_EVENT)" );
+         // pour pipiche
+            ZPS_tsAfEvent* psStackEvent = psEvent->pZPSevent;
+            if (psStackEvent->eType == ZPS_EVENT_APS_DATA_INDICATION)
+            {
+            	Znc_vSendDataIndicationToHost(psStackEvent, au8LinkTxBuffer);
+            }
         }
         break;
 

--- a/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl_event.c
+++ b/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl_event.c
@@ -950,7 +950,6 @@ PRIVATE void vZCL_HandleDataIndication(ZPS_tsAfEvent *pZPSevent)
                 else
 #endif
                 {
-                    // fix pipiche
                     sZCL_CallBackEvent.eEventType = E_ZCL_CBET_UNHANDLED_EVENT;
                     sZCL_CallBackEvent.u8EndPoint = pZPSevent->uEvent.sApsDataIndEvent.u8DstEndpoint;
                     vZCL_PassEventToUser(&sZCL_CallBackEvent);

--- a/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl_event.c
+++ b/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl_event.c
@@ -910,7 +910,10 @@ PRIVATE void vZCL_HandleDataIndication(ZPS_tsAfEvent *pZPSevent)
                 		 	*/
 
                 	}else{
-                		eZCL_SendDefaultResponse(pZPSevent, E_ZCL_CMDS_UNSUPPORTED_CLUSTER);
+                        sZCL_CallBackEvent.eEventType = E_ZCL_CBET_UNHANDLED_EVENT;
+                        sZCL_CallBackEvent.u8EndPoint = pZPSevent->uEvent.sApsDataIndEvent.u8DstEndpoint;
+                        vZCL_PassEventToUser(&sZCL_CallBackEvent);
+                        //eZCL_SendDefaultResponse(pZPSevent, E_ZCL_CMDS_UNSUPPORTED_CLUSTER);
                 	}
                 }
                 else
@@ -947,8 +950,12 @@ PRIVATE void vZCL_HandleDataIndication(ZPS_tsAfEvent *pZPSevent)
                 else
 #endif
                 {
+                    // fix pipiche
+                    sZCL_CallBackEvent.eEventType = E_ZCL_CBET_UNHANDLED_EVENT;
+                    sZCL_CallBackEvent.u8EndPoint = pZPSevent->uEvent.sApsDataIndEvent.u8DstEndpoint;
+                    vZCL_PassEventToUser(&sZCL_CallBackEvent);
 
-                eZCL_SendDefaultResponse(pZPSevent, E_ZCL_CMDS_UNSUPPORTED_CLUSTER);
+                //eZCL_SendDefaultResponse(pZPSevent, E_ZCL_CMDS_UNSUPPORTED_CLUSTER);
                 }
             }
             else


### PR DESCRIPTION
When a request comes for a specific cluster and it is unkown, we use to send a unsupported cluster message. Now we send it as an aps inidication to the client to be dealt with