### PR TITLE
Fix 24 bits types handling

### DIFF
--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
@@ -1543,7 +1543,8 @@ PUBLIC uint16 APP_u16ZncWriteDataPattern ( uint8*                    pu8Data,
                     u32Val |= (0xff << 24);
                 }
             }
-            memcpy(pu8Data, &u32Val, sizeof(uint32));
+            u32Val = u32Val << 8;
+            memcpy(pu8Data, &u32Val , sizeof(uint32)-1);
             // increment ptr to keep size calculation correct
             pu8Struct++;
             break;


### PR DESCRIPTION
It is stored in a 32 bits C type but we copy into a 32 bits array for sending which is wrong. Code is changed to copy into 24bits structure
Further fixing would include sending back a shorter length as the function sends back 4 bytes length instead of 3 bytes.
I suspect the other structure like 40bits and 56bits have the same issue
Orignal issue was that when sending 0x123456 was ending up as 0x345600 on the zigbee sniffer