### PR TITLE
Change meaning of 8000 API

### DIFF
--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/zps_struct.h
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/zps_struct.h
@@ -1,0 +1,382 @@
+/*
+ * zps_struct.h
+ *
+ *  Created on: 18 Jun 2020
+ *      Author: I051873
+ */
+
+#ifndef ZPS_STRUCT_H_
+#define ZPS_STRUCT_H_
+
+
+#define ZPS_APL_ZDO_VSOUI_LENGTH		3
+/*** ZDP Context **************************************************/
+
+typedef struct {
+    uint8 u8ZdpSeqNum;
+} zps_tsZdpContext;
+
+/*** ZDO Context **************************************************/
+
+typedef bool (*zps_tprAplZdoServer)(void *pvApl, void *pvServerContext, ZPS_tsAfEvent *psZdoServerEvent);
+
+typedef struct {
+    zps_tprAplZdoServer prServer;
+    void *pvServerContext;
+} zps_tsAplZdoServer;
+
+typedef struct
+{
+    uint8               au8Key[ZPS_NWK_KEY_LENGTH];
+    uint8               u8KeySeqNum;
+    uint8               u8KeyType;
+} zps_tsAplZdoInitSecKey;
+
+typedef struct {
+    uint64 u64InitiatorAddr;
+    uint64 u64ResponderAddr;
+    ZPS_tsTsvTimer sTimer;
+    uint8 au8Key[ZPS_NWK_KEY_LENGTH];
+} zps_tsRequestKeyRequests;
+
+
+typedef struct {
+    uint8 au8VsOUIBytes[ZPS_APL_ZDO_VSOUI_LENGTH] __attribute__ ((aligned (16)));
+    uint8 eNetworkState; /* ZPS_teZdoNetworkState */
+    uint8 eZdoDeviceType; /* ZPS_teZdoDeviceType */
+    uint8 eNwkKeyState; /* ZPS_teZdoNwkKeyState */
+    uint8 u8PermitJoinTime;
+    uint8 u8StackProfile;
+    uint8 u8ZigbeeVersion;
+    uint8 u8ScanDuration;
+    bool_t bLookupTCAddr;
+    const zps_tsAplZdoServer *psZdoServers;
+    void (*prvZdoServersInit)(void);
+    ZPS_tsTsvTimer sAuthenticationTimer;
+    ZPS_tsTsvTimer sAuthenticationPollTimer;
+    uint8 u8NumPollFailures;
+    uint8 u8MaxNumPollFailures;
+    bool_t bSecurityDisabled;
+    zps_tsAplZdoInitSecKey *psInitSecKey;
+    uint8 u8DevicePermissions;
+    bool_t (*prvZdoReqFilter)(uint16);
+    bool (*pfzps_bAplZdoBindRequestServer)(void *,
+            void *,
+            ZPS_tsAfEvent *);
+    zps_tsRequestKeyRequests *psRequestKeyReqs;
+    uint32 u32ReqKeyTimeout;
+    uint8 u8MaxNumSimulRequestKeyReqs;
+
+} zps_tsZdoContext;
+
+/**** Context for the ZDO servers data confirms and acks***********/
+
+typedef struct {
+    uint8 eState;
+    uint8 u8SeqNum;
+    uint8 u8ConfAck;
+} zps_tsZdoServerConfAckContext;
+
+/*** Trust Center Context *****************************************/
+
+typedef struct
+{
+    uint16 u16AddrLkup;
+    ZPS_teDevicePermissions eDevPermissions;
+} zps_tsAplTCDeviceTable;
+
+typedef struct
+{
+    zps_tsAplTCDeviceTable *asTCDeviceTable;
+    uint16  u16SizeOfTCDeviceTable;
+} zps_tsAplTCib;
+
+
+typedef struct
+{
+    void (*prvTrustCenterInit)(void*);
+    void (*prvTrustCenterUpdateDevice)(void*, uint64, uint64, uint8, uint16);
+    void (*prvTrustCenterRequestKey)(void*, uint64, uint8, uint64);
+    zps_tsAplTCib sTCib;
+    bool_t bTcOverride;
+    bool_t bChangeOverride;
+} zps_tsTrustCenterContext;
+
+/*** AF Context ***************************************************/
+
+typedef struct zps_tsAplAfDynamicContext zps_tsAplAfDynamicContext;
+
+typedef struct _zps_tsAplAfSimpleDescCont
+{
+    ZPS_tsAplAfSimpleDescriptor sSimpleDesc;
+    const PDUM_thAPdu *phAPduInClusters;
+    bool_t bEnabled;
+} zps_tsAplAfSimpleDescCont;
+
+typedef struct {
+    zps_tsAplAfDynamicContext *psDynamicContext;
+    ZPS_tsAplAfNodeDescriptor *psNodeDescriptor;
+    ZPS_tsAplAfNodePowerDescriptor *psNodePowerDescriptor;
+    uint32 u32NumSimpleDescriptors;
+    zps_tsAplAfSimpleDescCont *psSimpleDescConts;
+    ZPS_tsAplAfUserDescriptor *psUserDescriptor;
+    void* hOverrunMsg;
+    uint8 zcp_u8FragApsAckValue;
+    uint8 zcp_u8FragBlockControl;
+} zps_tsAfContext;
+
+/*** APS Context **************************************************/
+
+typedef struct
+{
+    uint8 u8Type;
+    uint8 u8ParamLength;
+} ZPS_tsAplApsmeDcfmIndHdr;
+
+typedef struct
+{
+    uint8 u8Type;
+    uint8 u8ParamLength;
+} ZPS_tsAplApsdeDcfmIndHdr;
+
+typedef struct {
+    ZPS_tuAddress uDstAddr;
+    PDUM_thAPduInstance hAPduInst;
+    uint8 *pu8SeqCounter;
+    uint16 u16ProfileId;
+    uint16 u16ClusterId;
+    uint8 u8DstEndpoint;
+    uint8 u8SrcEndpoint;
+    uint8 u8Radius;
+    uint8 eDstAddrMode;
+    uint8 eTxOptions;
+} ZPS_tsAplApsdeReqData;
+
+typedef union
+{
+    ZPS_tsAplApsdeReqData  sReqData;
+} ZPS_tuAplApsdeReqRspParam;
+
+typedef struct
+{
+    uint8                 u8Type;
+    uint8                 u8ParamLength;
+    uint16                u16Pad;
+    ZPS_tuAplApsdeReqRspParam uParam;
+} ZPS_tsAplApsdeReqRsp;
+
+typedef struct
+{
+    struct {
+        uint32 u6Reserved       : 6;
+        uint32 u2Fragmentation  : 2;
+        uint32 u24Padding       : 24;
+    } sEFC;
+    uint8 u8BlockNum;
+    uint8 u8Ack;
+} zps_tsExtendedFrameControlField;
+
+typedef union {
+    struct {
+        uint8   u8DstEndpoint;
+        uint16  u16ClusterId;
+        uint16  u16ProfileId;
+        uint8   u8SrcEndpoint;
+        uint8   u8ApsCounter;
+    } sUnicast;
+
+    struct {
+            uint16  u16GroupAddr;
+            uint16  u16ClusterId;
+            uint16  u16ProfileId;
+            uint8   u8SrcEndpoint;
+            uint8   u8ApsCounter;
+        } sGroup;
+} zps_tuApsAddressingField;
+
+typedef struct {
+    uint16    *psDuplicateTableSrcAddr;
+    uint32    *psDuplicateTableHash;
+    uint8     *psDuplicateTableApsCnt;
+    uint8     u8TableIndex;
+} zps_tsApsDuplicateTable;
+
+typedef struct zps_tsMsgRecord_tag {
+    struct zps_tsMsgRecord_tag *psNext;
+    ZPS_tsAplApsdeReqRsp sApsdeReqRsp;
+    ZPS_tsTsvTimer sAckTimer;       /* ack timer */
+    uint8       u8ReTryCnt;
+    uint8       u8ApsCount;
+} zps_tsMsgRecord;
+
+typedef struct zps_tsDcfmRecord_tag{
+    union {
+        uint16 u16DstAddr;
+        uint64 u64DstAddr;
+    };
+    uint8   u8Handle;
+    uint8   u8SrcEp;
+    uint8   u8DstEp;
+    uint8   u8DstAddrMode;
+    uint8   u8SeqNum;
+} zps_tsDcfmRecord;
+
+typedef struct zps_tsDcfmRecordPool_tag{
+    zps_tsDcfmRecord *psDcfmRecords;
+    uint8 u8NextHandle;
+    uint8 u8NumRecords;
+} zps_tsDcfmRecordPool;
+
+typedef struct zps_tsFragmentTransmit_tag {
+    enum {
+        ZPS_FRAG_TX_STATE_IDLE,
+        ZPS_FRAG_TX_STATE_SENDING,
+        ZPS_FRAG_TX_STATE_RESENDING,
+        ZPS_FRAG_TX_STATE_WAIT_FOR_ACK
+    }eState;
+    PDUM_thAPduInstance hAPduInst;
+    uint16  u16DstAddress;
+    uint16  u16ProfileId;
+    uint16  u16ClusterId;
+    uint8   u8DstEndpoint;
+    uint8   u8SrcEndpoint;
+    uint8   u8Radius;
+    uint8   u8SeqNum;
+
+    ZPS_tsTsvTimer sAckTimer;
+    uint8   u8CurrentBlock;
+    uint8   u8SentBlocksInWindow;
+    uint8   u8MinBlockNumber;
+    uint8   u8MaxBlockNumber;
+    uint8   u8TotalBlocksToSend;
+    uint8   u8RetryCount;
+    uint8   u8AckedBlocksInWindow;
+    uint8   u8WindowSize;
+    uint8   u8BlockSize;
+    bool_t  bSecure;
+} zps_tsFragmentTransmit;
+
+typedef struct zps_tsfragTxPool_tag {
+    zps_tsFragmentTransmit *psFragTxRecords;
+    uint8   u8NumRecords;
+} zps_tsFragTxPool;
+
+typedef struct zps_tsFragmentReceive_tag {
+    enum {
+        ZPS_FRAG_RX_STATE_IDLE,
+        ZPS_FRAG_RX_STATE_RECEIVING,
+        ZPS_FRAG_RX_STATE_PERSISTING
+    }eState;
+    PDUM_thAPduInstance hAPduInst;
+    uint16  u16SrcAddress;
+    uint16  u16ProfileId;
+    uint16  u16ClusterId;
+    uint8   u8DstEndpoint;
+    uint8   u8SrcEndpoint;
+    uint8   u8SeqNum;
+
+    ZPS_tsTsvTimer  sWindowTimer;
+    PDUM_thNPdu     hNPduPrevious;
+    uint16  u16ReceivedBytes;
+    uint8   u8TotalBlocksToReceive;
+    uint8   u8ReceivedBlocksInWindow;
+    uint8   u8MinBlockNumber;
+    uint8   u8MaxBlockNumber;
+    uint8   u8HighestUnAckedBlock;
+    uint8   u8WindowSize;
+    uint8   u8BlockSize;
+    uint8   u8PreviousBlock;
+} zps_tsFragmentReceive;
+
+typedef struct zps_tsfragRxPool_tag {
+    zps_tsFragmentReceive *psFragRxRecords;
+    uint8   u8NumRecords;
+    uint8   u8PersistanceTime;
+} zps_tsFragRxPool;
+
+typedef struct zps_tsApsPollTimer {
+    ZPS_tsTsvTimer sPollTimer;
+    uint16 u16PollInterval;
+    uint8 u8PollActive;
+} zps_tsApsPollTimer;
+
+typedef struct zps_tsApsmeCmdContainer {
+    struct zps_tsApsmeCmdContainer *psNext; /* must be first element of struct */
+    ZPS_tsNwkNldeReqRsp sNldeReqRsp;
+    ZPS_tsTsvTimer sTimer;
+    PDUM_thNPdu hNPduCopy;
+    uint8 u8Retries;
+} zps_tsApsmeCmdContainer;
+
+typedef struct {
+    zps_tsApsmeCmdContainer *psFreeList;
+    zps_tsApsmeCmdContainer *psSubmittedList;
+} zps_tsApsmeCmdMgr;
+
+typedef struct {
+    void* pvParam;
+    ZPS_tsAplApsdeDcfmIndHdr *psApsdeDcfmIndHdr;
+}zps_tsLoopbackDataContext;
+
+typedef struct {
+    /* APSDE */
+    void *pvParam;
+    ZPS_tsAplApsdeDcfmIndHdr *(*prpsGetApsdeBuf)(void *);
+    void (*prvPostApsdeDcfmInd)(void *, ZPS_tsAplApsdeDcfmIndHdr *);
+    /* APSME */
+    void *pvApsmeParam;
+    ZPS_tsAplApsmeDcfmIndHdr *(*prpsGetApsmeBuf)(void *);
+    void (*prvPostApsmeDcfmInd)(void *, ZPS_tsAplApsmeDcfmIndHdr *);
+
+    zps_tsApsDuplicateTable *psApsDuplicateTable;
+    zps_tsMsgRecord  *psSyncMsgPool;
+    uint8 u8ApsDuplicateTableSize;
+    uint8 u8SeqNum;
+    uint8 u8SyncMsgPoolSize;
+    uint8 u8MaxFragBlockSize;
+    zps_tsDcfmRecordPool sDcfmRecordPool;
+    zps_tsFragRxPool sFragRxPool;
+    zps_tsFragTxPool sFragTxPool;
+    ZPS_teStatus (*preStartFragmentTransmission)(void *, ZPS_tsAplApsdeReqRsp *, uint16, uint8);
+    void (*prvHandleExtendedDataAck)(void *, ZPS_tsNwkNldeDcfmInd *, zps_tuApsAddressingField *, zps_tsExtendedFrameControlField *);
+    void (*prvHandleDataFragmentReceive)(void *, ZPS_tsAplApsdeDcfmIndHdr *);
+    zps_tsApsmeCmdMgr sApsmeCmdMgr;
+    zps_tsApsPollTimer sApsPollTimer;
+    zps_tsLoopbackDataContext sLoopbackContext;
+    ZPS_tsTsvTimer sLoopbackTimer;
+} zps_tsApsContext;
+
+/*** APL Context **************************************************/
+
+typedef struct {
+    void *pvNwk;
+    const void *pvNwkTableSizes;
+    const void *pvNwkTables;
+
+    ZPS_tsNwkNib *psNib;
+    ZPS_tsAplAib *psAib;
+
+    void* hZpsMutex;
+    void* hDefaultStackEventMsg;
+    void* hMcpsDcfmIndMsg;
+    void* hMlmeDcfmIndMsg;
+    void* hTimeEventMsg;
+    void* hMcpsDcfmMsg;
+    /* sub-layer contexts */
+    zps_tsZdpContext sZdpContext;
+    zps_tsZdoContext sZdoContext;
+    zps_tsAfContext  sAfContext;
+    zps_tsApsContext sApsContext;
+
+    /* trust center context if present */
+    zps_tsTrustCenterContext *psTrustCenterContext;
+
+} zps_tsApl;
+/*** APL Context **************************************************/
+
+
+
+
+
+
+#endif /* ZPS_STRUCT_H_ */


### PR DESCRIPTION
so now 0x8000 has two new parameters
u8SeqNum and u8RequestSent

all 0x8000 parameters are as follow
u8Status      : as before - returned value of the function call
u8SeqNum      : as before - ZCL sqn and ZDP sqn
u16PacketType : as before - command requested
u8RequestSent : new       - 1 if a request been sent to a device(aps ack/nack 8011 should be expected) , 0 otherwise
u8SeqApsNum   : new       - sqn of the APS layer - used to check sqn sent back in aps ack

The purpose is to be able to get the APS sqn for all functions in order to find the APS ACK/NACK corresponding to this call