### PR TITLE
Fix configure report response

### DIFF
--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
@@ -623,10 +623,27 @@ PRIVATE void APP_ZCL_cbEndpointCallback ( tsZCL_CallBackEvent*    psEvent )
             ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [0],          psEvent->u8TransactionSequenceNumber,                                        u16Length );
             ZNC_BUF_U16_UPD ( &au8LinkTxBuffer [u16Length],  psEvent->pZPSevent->uEvent.sApsDataIndEvent.uSrcAddress.u16Addr,             u16Length );
             ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [u16Length],  psEvent->pZPSevent->uEvent.sApsDataIndEvent.u8SrcEndpoint,                   u16Length );
+            ZNC_BUF_U16_UPD ( &au8LinkTxBuffer [u16Length],  psEvent->psClusterInstance->psClusterDefinition->u16ClusterEnum,             u16Length );
+            ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [u16Length],  psEvent->eZCL_Status,                                                        u16Length );
+            vSL_WriteMessage ( E_SL_MSG_CONFIG_REPORTING_RESPONSE,
+                               u16Length,
+                               au8LinkTxBuffer,
+                               u8LinkQuality );
+        }
+        break;
+
+        case E_ZCL_CBET_REPORT_INDIVIDUAL_ATTRIBUTES_CONFIGURE_RESPONSE:
+        {
+            vLog_Printf ( TRACE_ZCL, LOG_DEBUG, " (E_ZCL_CBET_REPORT_INDIVIDUAL_ATTRIBUTES_CONFIGURE_RESPONSE)" );
+
+            /* Send event upwards */
+            ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [0],          psEvent->u8TransactionSequenceNumber,                                        u16Length );
+            ZNC_BUF_U16_UPD ( &au8LinkTxBuffer [u16Length],  psEvent->pZPSevent->uEvent.sApsDataIndEvent.uSrcAddress.u16Addr,             u16Length );
+            ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [u16Length],  psEvent->pZPSevent->uEvent.sApsDataIndEvent.u8SrcEndpoint,                   u16Length );
             ZNC_BUF_U16_UPD ( &au8LinkTxBuffer [u16Length], psEvent->psClusterInstance->psClusterDefinition->u16ClusterEnum,              u16Length );
             //FRED
-            ZNC_BUF_U16_UPD ( &au8LinkTxBuffer [u16Length],  psEvent->uMessage.sAttributeReportingConfigurationResponse.sAttributeReportingConfigurationRecord.u16AttributeEnum,              u16Length );
-            ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [u16Length], psEvent->uMessage.sAttributeReportingConfigurationResponse.eCommandStatus,    u16Length );
+            ZNC_BUF_U16_UPD ( &au8LinkTxBuffer [u16Length],  psEvent->uMessage.sReportingConfigurationResponse.u16AttributeEnum,              u16Length );
+            ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [u16Length], psEvent->uMessage.sReportingConfigurationResponse.u8Status,    u16Length );
             vSL_WriteMessage ( E_SL_MSG_CONFIG_REPORTING_RESPONSE,
                                u16Length,
                                au8LinkTxBuffer,

--- a/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl_configureReportingResponseHandle.c
+++ b/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl_configureReportingResponseHandle.c
@@ -162,10 +162,7 @@ PUBLIC  void vZCL_HandleConfigureReportingResponse(
                     pZPSevent->uEvent.sApsDataIndEvent.hAPduInst, u16inputOffset, E_ZCL_ATTRIBUTE_ID, &sZCL_CallBackEvent.uMessage.sReportingConfigurationResponse.u16AttributeEnum);
 
                 // call user for every attribute
-                if(sZCL_CallBackEvent.uMessage.sReportingConfigurationResponse.u8Status != E_ZCL_CMDS_SUCCESS)
-                {
-                    psZCL_EndPointDefinition->pCallBackFunctions(&sZCL_CallBackEvent);
-                }
+                psZCL_EndPointDefinition->pCallBackFunctions(&sZCL_CallBackEvent);
 
                 // check for length error
                 if((u16payloadSize-u16inputOffset !=0) && (u16payloadSize-u16inputOffset < 3))
@@ -173,12 +170,12 @@ PUBLIC  void vZCL_HandleConfigureReportingResponse(
                     sZCL_CallBackEvent.eZCL_Status = E_ZCL_ERR_MALFORMED_MESSAGE;
                 }
             }
+        } else {
+            sZCL_CallBackEvent.eEventType = E_ZCL_CBET_REPORT_ATTRIBUTES_CONFIGURE_RESPONSE;
+            psZCL_EndPointDefinition->pCallBackFunctions(&sZCL_CallBackEvent);
         }
-
-        sZCL_CallBackEvent.eEventType = E_ZCL_CBET_REPORT_ATTRIBUTES_CONFIGURE_RESPONSE;
     }
 
-    psZCL_EndPointDefinition->pCallBackFunctions(&sZCL_CallBackEvent);
 
     if(sZCL_CallBackEvent.eZCL_Status != E_ZCL_SUCCESS)
     {


### PR DESCRIPTION
1/
There was an issue with the struct being used :
sReportingConfigurationResponse is for config report response
sAttributeReportingConfigurationResponse is for read config report response
for this , we should use sReportingConfigurationResponse
2/
E_ZCL_CBET_REPORT_INDIVIDUAL_ATTRIBUTES_CONFIGURE_RESPONSE was reported only for report with error
3/
E_ZCL_CBET_REPORT_ATTRIBUTES_CONFIGURE_RESPONSE was the only reported in E_SL_MSG_CONFIG_REPORTING_RESPONSE