### PR TITLE
make WriteAttribute to report short response with no attribute id whe…

### DIFF
--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
@@ -480,6 +480,18 @@ PRIVATE void APP_ZCL_cbEndpointCallback ( tsZCL_CallBackEvent*    psEvent )
 
 
         case E_ZCL_CBET_WRITE_ATTRIBUTES_RESPONSE:
+            ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [0],          psEvent->u8TransactionSequenceNumber,                               u16Length );
+            ZNC_BUF_U16_UPD ( &au8LinkTxBuffer [u16Length],  psEvent->pZPSevent->uEvent.sApsDataIndEvent.uSrcAddress.u16Addr,    u16Length );
+            ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [u16Length],  psEvent->pZPSevent->uEvent.sApsDataIndEvent.u8SrcEndpoint,          u16Length );
+            ZNC_BUF_U16_UPD ( &au8LinkTxBuffer [u16Length],  psEvent->pZPSevent->uEvent.sApsDataIndEvent.u16ClusterId,           u16Length );
+            ZNC_BUF_U8_UPD  ( &au8LinkTxBuffer [u16Length],  psEvent->eZCL_Status,                                               u16Length );
+
+            vSL_WriteMessage ( E_SL_MSG_WRITE_ATTRIBUTE_RESPONSE,
+                               u16Length,
+                               au8LinkTxBuffer,
+                               u8LinkQuality );
+        break;
+        case E_ZCL_CBET_WRITE_INDIVIDUAL_ATTRIBUTE_RESPONSE:
         case E_ZCL_CBET_REPORT_INDIVIDUAL_ATTRIBUTE:
         case E_ZCL_CBET_READ_INDIVIDUAL_ATTRIBUTE_RESPONSE:
         {

--- a/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl_WriteAttributesResponseHandle.c
+++ b/Module Radio/Firmware/src/sdk/JN-SW-4170/Components/ZCIF/Source/zcl_WriteAttributesResponseHandle.c
@@ -161,14 +161,13 @@ PUBLIC void   vZCL_HandleAttributesWriteResponse(
                 // call user for every attribute
                 psZCL_EndPointDefinition->pCallBackFunctions(&sZCL_CallBackEvent);
             }
+        } else {
+            sZCL_CallBackEvent.eZCL_Status = eAttributeStatus;
+            sZCL_CallBackEvent.eEventType = E_ZCL_CBET_WRITE_ATTRIBUTES_RESPONSE;
+            psZCL_EndPointDefinition->pCallBackFunctions(&sZCL_CallBackEvent);
         }
-
-        // re-use last attribute generated structure for message but indicate command is complete, last attribute
-        // will get 2 callbacks effectively
-        sZCL_CallBackEvent.eEventType = E_ZCL_CBET_WRITE_ATTRIBUTES_RESPONSE;
     }
 
-    psZCL_EndPointDefinition->pCallBackFunctions(&sZCL_CallBackEvent);
 
     // incoming message is now parsed ok - send the default OK, if required
     eZCL_SendDefaultResponse(pZPSevent, E_ZCL_CMDS_SUCCESS);


### PR DESCRIPTION
…n everything is ok

and attribute id when they are problems

it changes slightly the protocol to have a reponse to writeattribute 8110 with no attribute id.
Indeed when everything is ok, firmware does not receive details about which writeattribute was ok 
However the existing 8110 with attribute ids when one had a problem is still there