### PR TITLE
All manufacturer id will be accepted

### DIFF
--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_start.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_start.c
@@ -1135,6 +1135,8 @@ bool_t APP_vProfileWideCommandSupportedForCluster ( uint16 u16Clusterid )
 
 bool_t APP_bZCL_IsManufacturerCodeSupported(uint16 u16ManufacturerCode)
 {
+	return TRUE;
+	/*
 	switch(u16ManufacturerCode)
 	{
 		// Ikea
@@ -1149,7 +1151,7 @@ bool_t APP_bZCL_IsManufacturerCodeSupported(uint16 u16ManufacturerCode)
 			return FALSE;
 		}
 	}
-	return FALSE;
+	return FALSE;*/
 }
 
 /****************************************************************************


### PR DESCRIPTION
Currently we have a list of exception for manufacrturer id when a request is manufacturer specific
With this fix, we allow all manufacturer id to be accepted. Normally if we do not know how to deal with it, it will generate a 8002 notification