### PR TITLE
Register only the endpoint 0x01

### DIFF
--- a/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
+++ b/Module Radio/Firmware/src/ZiGate/Source/ZigbeeNodeControlBridge/app_zcl_event_handler.c
@@ -1358,7 +1358,7 @@ void vAPP_ZCL_DeviceSpecific_Init ( void )
  ****************************************************************************/
 teZCL_Status eApp_ZLO_RegisterEndpoint ( tfpZCL_ZCLCallBackFunction    fptr )
 {
-
+/*
 	eZLO_RegisterControlBridgeEndPoint ( ZIGBEENODECONTROLBRIDGE_ORVIBO_ENDPOINT,
 	                                                fptr,
 	                                                &sControlBridge );
@@ -1375,7 +1375,7 @@ teZCL_Status eApp_ZLO_RegisterEndpoint ( tfpZCL_ZCLCallBackFunction    fptr )
 	eZLO_RegisterControlBridgeEndPoint ( ZIGBEENODECONTROLBRIDGE_WISER_ENDPOINT,
 				                                                fptr,
 				                                                &sControlBridge );
-
+*/
     return eZLO_RegisterControlBridgeEndPoint ( ZIGBEENODECONTROLBRIDGE_ZLO_ENDPOINT,
                                                 fptr,
                                                 &sControlBridge );


### PR DESCRIPTION
We used to register each endpoint using the same controlBridge structure.
However in the zcl.c, we override to endpoint 0x01. Thus registering would just increase heap footprint with no additional benefit
We will have to check in zcl_search if we want to maintain a list of endpoint in eZCL_SearchForEPIndex or just send back the index of endpoint 0x01 everytime